### PR TITLE
prefix when generating a groupId

### DIFF
--- a/src/cmds/consume.mjs
+++ b/src/cmds/consume.mjs
@@ -7,7 +7,7 @@ export default {
     desc: 'Consume messages on a topic',
     builder: {},
     handler: async function (argv) {
-        const groupId = argv.grp ?? uuid.v4();
+        const groupId = argv.grp ?? `kafkat-${uuid.v4()}`;
 
         console.log(`Consumer ${groupId} on topic ${argv.topic} - press Ctrl+C to exit\n`);
 


### PR DESCRIPTION
Just a little fix in order to easily spot kafkat groupIds when working with an architecture inducing lots of groupIds.