### PR TITLE
feat: describe command

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,19 +4,19 @@
 
 Add these environment variables to connect to your kafka cluster.
 
-Name | Description
---- | ---
-`KAFKAT_BROKERS` | List of brokers (separated by comas)
-`KAFKAT_SSL` | `true` or `false`
-`KAFKAT_SASL_MECHANISM` | `PLAIN` or `SCRAM-SHA-256`
-`KAFKAT_SASL_USERNAME` | Username
-`KAFKAT_SASL_PASSWORD` | Password
-`KAFKAT_SCHEMA_REGISTRY` | Schema registry host (optional)
-
+| Name                     | Description                          |
+| ------------------------ | ------------------------------------ |
+| `KAFKAT_BROKERS`         | List of brokers (separated by comas) |
+| `KAFKAT_SSL`             | `true` or `false`                    |
+| `KAFKAT_SASL_MECHANISM`  | `PLAIN` or `SCRAM-SHA-256`           |
+| `KAFKAT_SASL_USERNAME`   | Username                             |
+| `KAFKAT_SASL_PASSWORD`   | Password                             |
+| `KAFKAT_SCHEMA_REGISTRY` | Schema registry host (optional)      |
 
 ## Commands
 
 ### List topics
+
 ```
 kafkat topic list [filter-regex] [--json]
 
@@ -26,7 +26,17 @@ kafkat topic list '^alpha.'    # list topics starting with alpha
 kafkat topic list --json       # list all topics as json
 ```
 
+### Describe topic
+
+```
+kafkat topic describe <topic-name>
+
+# Example
+kafkat topic describe orders-topic    # show detailed information about orders-topic
+```
+
 ### Create topic
+
 ```
 kafkat topic create <topic-name> [--part] [--repl]
 
@@ -38,6 +48,7 @@ kafkat topic create else-topic --part 6 --repl 1
 ```
 
 ### Delete topics
+
 ```
 kafkat topic delete <topic-names...>
 
@@ -47,12 +58,14 @@ kafkat topic delete orders-topic todo-topic some-topic else-topic
 ```
 
 ### Find and delete topics
+
 ```
 # delete all topics starting by alpha.
 kafkat topic list '^alpha.' | xargs kafkat topic delete
 ```
 
 ### Produce message to topic
+
 ```
 # Usage
 kafkat produce <topic-name> <message> [--avdl] [--avsc] [--num]
@@ -67,6 +80,7 @@ kafkat produce milk-topic '{ "name": "can of milk", "amount": "12" }' --avsc=mil
 ```
 
 ### Consume messages from topic
+
 ```
 kafkat consume <topic-name> [--earliest] [--schema] [--grp=group-id]
 
@@ -78,6 +92,7 @@ kafkat consume orders-topic --schema      # decode consumed messages with schema
 ```
 
 ### Retrieve consumer group offsets
+
 ```
 kafkat offsets <groupId> [--topic] [--regex]
 
@@ -87,6 +102,7 @@ kafkat offsets consumer-group-2 --regex '^alpha.'       # get aggregated offsets
 ```
 
 ### Manage consumer groups
+
 ```
 kafkat consumer-group <groupId> [aliases: cm]
 
@@ -96,6 +112,7 @@ kafkat cm delete my-consumer-group-id
 ```
 
 ### Generate typescript interface from avro schema
+
 ```
 kafkat avro-ts [--registryId] [--subject] [--avsc]
 
@@ -110,6 +127,7 @@ kafkat avro-ts --subject orders-value    # generate typescript from subject's la
 An easy way to switch between different configurations is to create a file `config-dev.sh` which exports environment variables. Then use `source config-dev.sh` to load them in the current shell.
 
 ### Using SASL/SCRAM on Cloud Karafka (single broker) + Schema Registry
+
 ```
 export KAFKAT_BROKERS='broker-01.srvs.cloudkafka.com:9094'
 export KAFKAT_SSL='true'
@@ -121,6 +139,7 @@ export KAFKAT_SCHEMA_REGISTRY='https://schema-registry.aws.com:8081'
 ```
 
 ### Using SASL on Confluent Cloud (3 brokers)
+
 ```
 export KAFKAT_BROKERS='confluent-cloud-01:9092,confluent-cloud-02:9092,confluent-cloud-03:9092'
 export KAFKAT_SSL='true'
@@ -130,6 +149,7 @@ export KAFKAT_SASL_PASSWORD='some-pass'
 ```
 
 ### Using local kafka instance and schema registry
+
 ```
 export KAFKAT_BROKERS='localhost:9092'
 export KAFKAT_SCHEMA_REGISTRY='http://localhost:8081'
@@ -147,5 +167,5 @@ Feel free to send Pull Requests.
 
 ## Tested with
 
-- Node 18.12.1
-- npm 8.19.2
+-   Node 18.12.1
+-   npm 8.19.2

--- a/src/cmds/topic.js
+++ b/src/cmds/topic.js
@@ -1,12 +1,13 @@
 import create from './topic_cmds/create.js';
 import delete_ from './topic_cmds/delete.js';
 import list from './topic_cmds/list.js';
+import describe from './topic_cmds/describe.mjs';
 
 export default {
     command: 'topic <command>',
     desc: 'Manage topics',
     builder: function (yargs) {
-        return yargs.command([create, list, delete_]).demandCommand(1);
+        return yargs.command([create, list, delete_, describe]).demandCommand(1);
     },
     handler: function () {},
 };

--- a/src/cmds/topic.js.orig
+++ b/src/cmds/topic.js.orig
@@ -1,0 +1,23 @@
+<<<<<<< HEAD:src/cmds/topic.js
+import create from './topic_cmds/create.js';
+import delete_ from './topic_cmds/delete.js';
+import list from './topic_cmds/list.js';
+||||||| parent of 9265108 (feat: describe command):src/cmds/topic.mjs
+import create from './topic_cmds/create.mjs';
+import delete_ from './topic_cmds/delete.mjs';
+import list from './topic_cmds/list.mjs';
+=======
+import create from './topic_cmds/create.mjs';
+import delete_ from './topic_cmds/delete.mjs';
+import describe from './topic_cmds/describe.mjs';
+import list from './topic_cmds/list.mjs';
+>>>>>>> 9265108 (feat: describe command):src/cmds/topic.mjs
+
+export default {
+    command: 'topic <command>',
+    desc: 'Manage topics',
+    builder: function (yargs) {
+        return yargs.command([create, list, delete_, describe]).demandCommand(1);
+    },
+    handler: function () {},
+};

--- a/src/cmds/topic_cmds/describe.mjs
+++ b/src/cmds/topic_cmds/describe.mjs
@@ -1,0 +1,58 @@
+import kafka from '../../kafka/kafka.mjs';
+
+export default {
+    command: 'describe <topic>',
+    desc: 'Describe a topic with detailed information',
+    builder: {},
+    handler: async function (argv) {
+        try {
+            // Fetch topic metadata
+            const metadata = await kafka.fetchTopicMetadata([argv.topic]);
+
+            if (!metadata.topics.length) {
+                console.error(`Topic '${argv.topic}' not found`);
+                return;
+            }
+
+            const topicMetadata = metadata.topics[0];
+
+            // Display topic information
+            console.log(`Topic: ${topicMetadata.name}`);
+            console.log(`Partitions: ${topicMetadata.partitions.length}`);
+
+            // Display partition details
+            console.log('\nPartition Details:');
+            console.log('----------------');
+            console.log('Partition | Leader | Replicas | ISR');
+            console.log('----------------');
+
+            for (const partition of topicMetadata.partitions) {
+                console.log(
+                    `${partition.partitionId.toString().padEnd(10)} | ` +
+                        `${partition.leader.toString().padEnd(7)} | ` +
+                        `[${partition.replicas.join(', ')}] | ` +
+                        `[${partition.isr.join(', ')}]`
+                );
+            }
+
+            // Fetch topic offsets
+            const offsets = await kafka.fetchTopicOffsets(argv.topic);
+
+            // Display offset information
+            console.log('\nOffset Information:');
+            console.log('----------------');
+            console.log('Partition | Offset | High Watermark');
+            console.log('----------------');
+
+            for (const offset of offsets) {
+                console.log(
+                    `${offset.partition.toString().padEnd(10)} | ` +
+                        `${offset.offset.toString().padEnd(7)} | ` +
+                        `${offset.high || 'N/A'}`
+                );
+            }
+        } catch (error) {
+            console.error(`Error describing topic: ${error.message}`);
+        }
+    },
+};

--- a/src/kafka/kafka.js
+++ b/src/kafka/kafka.js
@@ -17,6 +17,10 @@ async function listTopics() {
     return await kafkaAdmin.listTopics();
 }
 
+async function fetchTopicMetadata(topics) {
+    return await kafkaAdmin.fetchTopicMetadata({ topics });
+}
+
 async function createTopic(topic, topicConfig) {
     return await kafkaAdmin.createTopics({
         waitForLeaders: true,
@@ -156,4 +160,5 @@ export default {
     consume,
     disconnect,
     deleteSingleConsumerGroup,
+    fetchTopicMetadata,
 };


### PR DESCRIPTION
I've added a new command to the kafkat CLI tool that allows users to describe a topic with detailed information. This is a useful addition to the existing commands for managing topics.

## Changes Made

1. Added a new `fetchTopicMetadata` method to `src/kafka/kafka.mjs` to fetch detailed information about topics
2. Created a new command file `src/cmds/topic_cmds/describe.mjs` that implements the describe command
3. Updated `src/cmds/topic.mjs` to include the new describe command
4. Updated `README.md` to document the new describe command

## How It Works

The new command allows users to get detailed information about a Kafka topic, including:
- Topic name
- Number of partitions
- Partition details (partition ID, leader, replicas, ISR)
- Offset information (partition, offset, high watermark)

## Usage

```
kafkat topic describe <topic-name>

# Example
kafkat topic describe orders-topic    # show detailed information about orders-topic
```